### PR TITLE
build: make the build task run all the npm build task also

### DIFF
--- a/buildSrc/src/main/kotlin/configure-npm.gradle.kts
+++ b/buildSrc/src/main/kotlin/configure-npm.gradle.kts
@@ -73,3 +73,13 @@ packageJson {
         "vitest" version "^2.0.0"
     }
 }
+
+tasks.named("clean") {
+    doLast {
+        delete("package-lock.json", "package.json")
+    }
+}
+
+tasks.register("build") {
+    dependsOn("npmBuild")
+}


### PR DESCRIPTION
With this PR:
* the `build` task will also invoke all the `npmBuild` tasks.
* the `clean` task will also delete the `package.json` and `package-lock.json` files.

Let me know if you notice any unexpected behaviors.